### PR TITLE
修复代码修改后的 docker 镜像构建不是最新v2raya问题

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya_${{ env.VERSION }}
+        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
+        files: v2raya_binaries/v2raya_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -150,8 +150,11 @@ jobs:
         file: install/docker/Dockerfile.Action
         platforms: linux/amd64
         push: true
+        build-args: |
+          VERSION=${{ steps.prep.outputs.tag }}
         tags: |
           ${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.tag }}
           ${{ steps.prep.outputs.image }}:latest
         cache-from: type=gha
-        cache-to: type=gha,mode=max 
+        cache-to: type=gha,mode=max
+

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Upload binary to GitHub Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ inputs.tag }}
+        tag_name: latest
         files: v2raya_binaries/v2raya_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
@@ -150,8 +150,6 @@ jobs:
         file: install/docker/Dockerfile.Action
         platforms: linux/amd64
         push: true
-        build-args: |
-          VERSION=${{ steps.prep.outputs.tag }}
         tags: |
           ${{ steps.prep.outputs.image }}:${{ steps.prep.outputs.tag }}
           ${{ steps.prep.outputs.image }}:latest

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -94,7 +94,7 @@ jobs:
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
         go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
-        ls ../v2raya_binaries/v2raya
+        ls -l /home/runner/work/v2rayA/v2rayA
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -94,7 +94,7 @@ jobs:
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
         go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
-        ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
+        ll /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -94,7 +94,7 @@ jobs:
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
         go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
-        ll /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
+        ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -94,6 +94,7 @@ jobs:
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
         go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
+        ls ../v2raya_binaries/v2raya
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -93,7 +93,7 @@ jobs:
         $env:GOARCH = 'amd64'
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
-        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
+        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
         ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
         Set-Location -Path ..
     - name: Upload Artifact

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
+        files: v2raya_binaries/v2raya_${filename}_${env:VERSION}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -93,8 +93,8 @@ jobs:
         $env:GOARCH = 'amd64'
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
-        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
-        ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries
+        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
+        ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya_${filename}_${env:VERSION}
+        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -118,7 +118,7 @@ jobs:
         version=$(echo ${{ inputs.tag }} | sed 's/v//g')
         echo "VERSION=$version" >> $GITHUB_OUTPUT
         echo "VERSION=$version" >> $GITHUB_ENV
-        IMAGE="jaybuckeye2006/v2raya"
+        IMAGE="wasd13579/v2raya"
         echo "image=${IMAGE}" >> $GITHUB_OUTPUT
         echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
         sed -i "s|Realv2rayAVersion|$version|g" install/docker/docker_helper.sh

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -93,7 +93,7 @@ jobs:
         $env:GOARCH = 'amd64'
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
-        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
+        go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
         ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries/*
         Set-Location -Path ..
     - name: Upload Artifact
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
+        files: v2raya_binaries/v2raya_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Upload binary to GitHub Release
       uses: softprops/action-gh-release@v1
       with:
-        tag_name: latest
+        tag_name: ${{ inputs.tag }}
         files: v2raya_binaries/v2raya
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -103,12 +103,12 @@ jobs:
           v2raya_binaries/*
     - name: Upload binary to GitHub Release
       uses: softprops/action-gh-release@v1
-      if: github.event_name == 'workflow_dispatch'  # 或根据你的触发方式调整
       with:
-        tag_name: ${{ inputs.tag }}
+        tag_name: latest
         files: v2raya_binaries/v2raya
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.docker }}
+
 
 
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -101,6 +101,18 @@ jobs:
       with:
         path: |
           v2raya_binaries/*
+    - name: Upload binary to GitHub Release
+      uses: softprops/action-gh-release@v1
+      if: github.event_name == 'workflow_dispatch'  # 或根据你的触发方式调整
+      with:
+        tag_name: ${{ inputs.tag }}
+        files: v2raya_binaries/v2raya
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+
+
 
   Release_v2rayA_to_Docker:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -94,7 +94,7 @@ jobs:
         $filename = $((Get-Content ./install/friendly-filenames.json | ConvertFrom-Json)."linux-amd64")."friendlyName"
         Set-Location -Path service
         go build -tags "with_gvisor" -o ../v2raya_binaries/v2raya_${filename}_${env:VERSION} -ldflags="-X github.com/v2rayA/v2rayA/conf.Version=${env:VERSION} -s -w" -trimpath
-        ls -l /home/runner/work/v2rayA/v2rayA
+        ls -l /home/runner/work/v2rayA/v2rayA/v2raya_binaries
         Set-Location -Path ..
     - name: Upload Artifact
       uses: nanoufo/action-upload-artifacts-and-release-assets@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -105,7 +105,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.tag }}
-        files: v2raya_binaries/v2raya
+        files: v2raya_binaries/v2raya_${{ env.filename }}_${{ env.VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.docker }}
 

--- a/install/docker/Dockerfile.Action
+++ b/install/docker/Dockerfile.Action
@@ -1,5 +1,6 @@
 FROM alpine:latest AS builder
 WORKDIR /
+RUN apk update && apk add --no-cache curl jq unzip bash
 COPY ./install/docker/docker_helper.sh ./docker_helper.sh
 COPY ./install/docker/iptables.sh ./iptables.sh
 COPY ./install/docker/ip6tables.sh ./ip6tables.sh

--- a/install/docker/Dockerfile.Action
+++ b/install/docker/Dockerfile.Action
@@ -3,10 +3,11 @@ WORKDIR /
 COPY ./install/docker/docker_helper.sh ./docker_helper.sh
 COPY ./install/docker/iptables.sh ./iptables.sh
 COPY ./install/docker/ip6tables.sh ./ip6tables.sh
+COPY ./install/docker/tproxy-hook.sh ./tproxy-hook.sh
 RUN sh -c "$(cat ./docker_helper.sh)"
 RUN rm ./docker_helper.sh
 EXPOSE 2017
 VOLUME /etc/v2raya
 #ENTRYPOINT ["v2raya"]
-ENTRYPOINT ["v2raya", "--transparent-hook", "/etc/v2raya/tproxy-hook.sh"]
+ENTRYPOINT ["v2raya", "--transparent-hook", "/tproxy-hook.sh"]
 

--- a/install/docker/Dockerfile.Action
+++ b/install/docker/Dockerfile.Action
@@ -7,4 +7,6 @@ RUN sh -c "$(cat ./docker_helper.sh)"
 RUN rm ./docker_helper.sh
 EXPOSE 2017
 VOLUME /etc/v2raya
-ENTRYPOINT ["v2raya"]
+#ENTRYPOINT ["v2raya"]
+ENTRYPOINT ["v2raya", "--transparent-hook", "/etc/v2raya/tproxy-hook.sh"]
+

--- a/install/docker/Dockerfile.Action
+++ b/install/docker/Dockerfile.Action
@@ -1,6 +1,5 @@
 FROM alpine:latest AS builder
 WORKDIR /
-RUN apk update && apk add --no-cache curl jq unzip bash
 COPY ./install/docker/docker_helper.sh ./docker_helper.sh
 COPY ./install/docker/iptables.sh ./iptables.sh
 COPY ./install/docker/ip6tables.sh ./ip6tables.sh

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -21,30 +21,12 @@ case "$(arch)" in
     *)
         ;;
 esac
-# 设置 GitHub 仓库信息
-OWNER="wasd13579"
-REPO="v2rayA"
-GITHUB_TOKEN="$GITHUB_TOKEN" 
-
-# 获取最新构建的 ID
-BUILD_ID=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/actions/runs" | jq -r '.workflow_runs[0].id')
-
-# 获取最新构建的产物链接
-ARTIFACTS=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$BUILD_ID/artifacts")
-ARTIFACT_URL=$(echo "$ARTIFACTS" | jq -r '.artifacts[0].archive_download_url')
-
-# 使用 wget 下载构建产物
-echo "Downloading artifact from: $ARTIFACT_URL"
-wget --header="Authorization: token $docker" "$ARTIFACT_URL" -O v2raya_linux_x64_latest.zip
-# 解压并安装
-unzip v2raya_linux_x64_latest.zip -d /usr/local/bin
-install /usr/local/bin/v2raya /usr/bin/v2raya
 
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
-wget https://github.com/v2rayA/v2rayA/releases/download/vRealv2rayAVersion/v2raya_linux_"$v2raya_arch"_Realv2rayAVersion
-unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
+wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
+unzip v2raya_linux_x64_latest.zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -21,16 +21,15 @@ case "$(arch)" in
     *)
         ;;
 esac
-
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
 wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
+unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray
 install ./v2raya /usr/local/bin/v2raya
-
 
 mkdir /usr/local/share/v2raya
 ln -s /usr/local/share/v2raya /usr/local/share/v2ray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -30,6 +30,8 @@ unzip v2raya_linux_x64_latest.zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray
+install ./v2raya /usr/local/bin/v2raya
+
 
 mkdir /usr/local/share/v2raya
 ln -s /usr/local/share/v2raya /usr/local/share/v2ray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -35,11 +35,11 @@ ARTIFACT_URL=$(echo "$ARTIFACTS" | jq -r '.artifacts[0].archive_download_url')
 
 # 使用 wget 下载构建产物
 echo "Downloading artifact from: $ARTIFACT_URL"
-wget --header="Authorization: Bearer $GITHUB_TOKEN" "$ARTIFACT_URL" -O v2raya_linux_x64_latest
-
+wget "$ARTIFACT_URL" -O v2raya_linux_x64_latest.zip
 # 解压并安装
-unzip /path/to/save/v2raya_linux_x64_latest.zip -d /usr/local/bin
-install /usr/local/bin/v2raya_linux_x64_latest /usr/bin/v2raya
+unzip v2raya_linux_x64_latest.zip -d /usr/local/bin
+install /usr/local/bin/v2raya /usr/bin/v2raya
+
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
@@ -48,7 +48,7 @@ unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray
-install ./v2raya_linux_x64_latest /usr/bin/v2raya
+
 mkdir /usr/local/share/v2raya
 ln -s /usr/local/share/v2raya /usr/local/share/v2ray
 ln -s /usr/local/share/v2raya /usr/local/share/xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -21,6 +21,25 @@ case "$(arch)" in
     *)
         ;;
 esac
+# 设置 GitHub 仓库信息
+OWNER="wasd13579"
+REPO="v2rayA"
+GITHUB_TOKEN="$GITHUB_TOKEN" 
+
+# 获取最新构建的 ID
+BUILD_ID=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/actions/runs" | jq -r '.workflow_runs[0].id')
+
+# 获取最新构建的产物链接
+ARTIFACTS=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/actions/runs/$BUILD_ID/artifacts")
+ARTIFACT_URL=$(echo "$ARTIFACTS" | jq -r '.artifacts[0].archive_download_url')
+
+# 使用 wget 下载构建产物
+echo "Downloading artifact from: $ARTIFACT_URL"
+wget --header="Authorization: Bearer $GITHUB_TOKEN" "$ARTIFACT_URL" -O v2raya_linux_x64_latest
+
+# 解压并安装
+unzip /path/to/save/v2raya_linux_x64_latest.zip -d /usr/local/bin
+install /usr/local/bin/v2raya_linux_x64_latest /usr/bin/v2raya
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
@@ -29,7 +48,7 @@ unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray
-install ./v2raya_linux_"$v2raya_arch"_Realv2rayAVersion /usr/bin/v2raya
+install ./v2raya_linux_x64_latest /usr/bin/v2raya
 mkdir /usr/local/share/v2raya
 ln -s /usr/local/share/v2raya /usr/local/share/v2ray
 ln -s /usr/local/share/v2raya /usr/local/share/xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -35,7 +35,7 @@ ARTIFACT_URL=$(echo "$ARTIFACTS" | jq -r '.artifacts[0].archive_download_url')
 
 # 使用 wget 下载构建产物
 echo "Downloading artifact from: $ARTIFACT_URL"
-wget "$ARTIFACT_URL" -O v2raya_linux_x64_latest.zip
+wget --header="Authorization: token $docker" "$ARTIFACT_URL" -O v2raya_linux_x64_latest.zip
 # 解压并安装
 unzip v2raya_linux_x64_latest.zip -d /usr/local/bin
 install /usr/local/bin/v2raya /usr/bin/v2raya

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 set -x
-ARG VERSION
-ENV VERSION=$VERSION
 current_dir=$(pwd)
 case "$(arch)" in
     x86_64)
@@ -26,8 +24,7 @@ esac
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
-#wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
-wget "https://github.com/wasd13579/v2rayA/releases/download/${VERSION}/v2raya_${VERSION}" 
+wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
 unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -x
+ARG VERSION
+ENV VERSION=$VERSION
 current_dir=$(pwd)
 case "$(arch)" in
     x86_64)
@@ -25,7 +27,7 @@ mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
 #wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
-wget https://github.com/wasd13579/v2rayA/releases/download/vRealv2rayAVersion/v2raya_linux_"$v2raya_arch"_Realv2rayAVersion
+wget "https://github.com/wasd13579/v2rayA/releases/download/${VERSION}/v2raya_${VERSION}" 
 unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -24,7 +24,8 @@ esac
 mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
-wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
+#wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
+wget https://github.com/wasd13579/v2rayA/releases/download/vRealv2rayAVersion/v2raya_linux_"$v2raya_arch"_Realv2rayAVersion
 unzip v2ray-linux-"$v2ray_arch".zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray

--- a/install/docker/docker_helper.sh
+++ b/install/docker/docker_helper.sh
@@ -26,7 +26,6 @@ mkdir -p build && cd build || exit
 wget https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$v2ray_arch.zip
 wget https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-$v2ray_arch.zip
 wget https://github.com/wasd13579/v2rayA/releases/download/latest/v2raya
-unzip v2raya_linux_x64_latest.zip -d v2ray
 install ./v2ray/v2ray /usr/local/bin/v2ray
 unzip Xray-linux-"$v2ray_arch".zip -d xray
 install ./xray/xray /usr/local/bin/xray

--- a/install/docker/tproxy-hook.sh
+++ b/install/docker/tproxy-hook.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# parse the arguments
+for i in "$@"; do
+  case $i in
+    --transparent-type=*)
+      TYPE="${i#*=}"
+      shift
+      ;;
+    --stage=*)
+      STAGE="${i#*=}"
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $i"
+      shift
+      ;;
+    *)
+      ;;
+  esac
+done
+
+
+case "$STAGE" in
+post-start)
+  # at the post-start stage
+  if [ "$TYPE" = "tproxy" ]; then
+    # we check if the transparent type is tproxy, and if so, we disable the bridge netfilter call and remove the docker rule in the TP_RULE chain.
+    modprobe br_netfilter
+    sysctl net.bridge.bridge-nf-call-ip6tables=0
+    sysctl net.bridge.bridge-nf-call-iptables=0
+    sysctl net.bridge.bridge-nf-call-arptables=0
+    iptables -t mangle -D TP_RULE -i br+ -j RETURN
+    iptables -t mangle -D TP_RULE -i docker+ -j RETURN
+  fi
+  ;;
+*)
+  ;;
+esac
+
+exit 0


### PR DESCRIPTION
代码修改后，当前的 Workflow 仍然会从官方仓库拉取 v2raya 二进制程序，导致构建出的 Docker 镜像未包含本地修改的 v2raya 版本。
优化方案：
    增加 Release 发布流程：在 Workflow 中添加 Release 任务，确保构建后发布 v2raya 二进制程序，并标记为 latest 版本。
    调整构建逻辑：修改镜像构建脚本，使其从 自定义仓库 拉取 v2raya 二进制文件，而不是默认的官方源，确保最终镜像基于 最新的自定义构建版本。
这样可以确保 Workflow 在执行时，总是使用 最新的自定义 v2raya 版本，而不是回退到官方的默认版本。